### PR TITLE
JAVA-103 - Make the documentation call out JDK 8 exclusively.  There …

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Quick start guide is intended to help you begin playing around with the Abs
 **Want to dig deeper into the Absio SDKs?**   See our complete **[API documentation](https://absio.github.io/java-sdk/)**.
 
 ## Java
-This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.
+This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.  This may not work for Java versions greater than 8.
 
 ### JCE
 Java uses the JCE to perform all cryptographic operations.  The SDK requires one modification to the JDK/JRE being used (for the JCE) as well as one initialization to ensure the JCE Absio depends on is used.

--- a/examples/key-management-app/README.md
+++ b/examples/key-management-app/README.md
@@ -4,7 +4,7 @@
 The intent of this Swing application is to show how to use all of the features of the Key Management portion of the SDK.
 
 ## Java
-This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.
+This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.  This may not work for Java versions greater than 8.
 
 ## Java Cryptography Extension (JCE) Unlimited Strength
 In order to use the SDK to perform any cryptography, the JDK/JRE must be updated for the [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)(this is for JDK 1.8).
@@ -14,9 +14,9 @@ Since there is no easy way to enter or display binary data, most of the inputs/o
 
 ## Compiling and Running on Windows
 
-1. Java JDK 8+
-    1. Download and install [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 8 or higher
-        1. If using JDK 8, install the [JCE Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+1. Java JDK 8
+    1. Download and install [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 8 (we test with OpenJDK)
+        1. If using Oracle's JDK 8, install the [JCE Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
     1. Create a JAVA_HOME environment variable and point it to the JDK installation folder (e.g. "C:\Program Files\Java\jdk1.8.0_161")
 1. Maven    
     1. Download and unpack [Maven](http://maven.apache.org/download.cgi) to a local folder

--- a/examples/key-management-app/pom.xml
+++ b/examples/key-management-app/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.absio</groupId>
     <artifactId>key-management-app</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/examples/user-management-shell/README.md
+++ b/examples/user-management-shell/README.md
@@ -4,7 +4,7 @@
 The intent of this shell application is to show how to use the key features of the Absio SDK and its use with the Absio Broker application.
 
 ## Java
-This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.
+This SDK was written with the Java 7 language level, but was tested exclusively against Java 8.  This may not work for Java versions greater than 8.
 
 ## Java Cryptography Extension (JCE) Unlimited Strength
 In order to use the SDK to perform any cryptography, the JDK/JRE must be updated for the [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)(this is for JDK 1.8).
@@ -15,9 +15,9 @@ The user management shell uses [Spring Shell](https://projects.spring.io/spring-
 
 ## Compiling and Running on Windows
 
-1. Java JDK 8+
-    1. Download and install [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 8 or higher
-        1. If using JDK 8, install the [JCE Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+1. Java JDK 8
+    1. Download and install [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 8 (we test with OpenJDK)
+        1. If using Oracle's JDK 8, install the [JCE Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
     1. Create a JAVA_HOME environment variable and point it to the JDK installation folder (e.g. "C:\Program Files\Java\jdk1.8.0_161")
 1. Maven    
     1. Download and unpack [Maven](http://maven.apache.org/download.cgi) to a local folder

--- a/examples/user-management-shell/pom.xml
+++ b/examples/user-management-shell/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.absio</groupId>
     <artifactId>user-management-shell</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <name>user-management-shell</name>


### PR DESCRIPTION
Make the documentation call out JDK 8 exclusively.  There are issues with newer JDK's that must be addressed.